### PR TITLE
npm command fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This project requires running two separate servers. A NodeJs HTTP server to deli
 * Install JavaScript depedencies:
 ````
 cd js/
-npm install -g browserify reactify
+npm install browserify
+npm install reactify
 npm install
 ````
 * Build web client:


### PR DESCRIPTION
npm install commands needed a quick fix. We have tried in a few different computers and -g flag didn't work for reactify.
